### PR TITLE
ci: add "type a version in a box" dispatch (rust-gem-release@0.11.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+.*"
   workflow_dispatch:
     inputs:
+      version:
+        type: string
+        default: ""
+        description: "Version to cut + release, e.g. 1.0.0 (blank = build-only dry-run)"
       publish:
         type: boolean
         default: false
@@ -28,10 +32,13 @@ jobs:
     # tags + manual dispatch always run; PRs run only when explicitly labelled
     # (the matrix is expensive — opt in per PR rather than on every push).
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'dry-run-release') }}
-    uses: scientist-labs/rust-gem-release/.github/workflows/release.yml@0.10.0
+    uses: scientist-labs/rust-gem-release/.github/workflows/release.yml@0.11.0
     with:
       gem-name: tokenkit
       version-command: ruby -r./lib/tokenkit/version -e 'print TokenKit::VERSION'
+      version: ${{ inputs.version }}
+      bump-command: |
+        sed -i 's/^\( *VERSION *= *\).*/\1"'"$VERSION"'"/' lib/tokenkit/version.rb
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     secrets:
       rubygems-api-key: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
Adopts **rust-gem-release@0.11.0** and adds the new **"type a version in a box"** release path.

**Surgical change** to the existing thin caller:
- bump the reusable-workflow pin `@0.10.0` → `@0.11.0`
- add an optional `version` input to `workflow_dispatch`
- pass `version` + a `bump-command` (sed on `lib/tokenkit/version.rb`) through to the shared workflow

Now releasable three ways: **CLI** (`git tag X && git push --tags`), **version box** (Actions → Run workflow → type a version + check publish), and a **version-less dry-run**. The tag-push path and the `dry-run-release` PR path are **byte-identical** to before.

⚠️ This PR does **not** bump the gem version — release with the agreed bump policy (precompiled gems: minor; CI-only: patch) via the box or a tag.

Companion to the merged rust-gem-release feature (bump-on-dispatch).